### PR TITLE
Replaced underscore with a dash

### DIFF
--- a/src/views/emails/passwordreset.blade.php
+++ b/src/views/emails/passwordreset.blade.php
@@ -3,8 +3,8 @@
 <p>{{ Lang::get('confide::confide.email.password_reset.greetings', array( 'name' => $user->username)) }},</p>
 
 <p>{{ Lang::get('confide::confide.email.password_reset.body') }}</p>
-<a href='{{{ URL::to("user/reset_password/".$token) }}}'>
-    {{{ URL::to("user/reset_password/".$token) }}}
+<a href='{{{ URL::to("user/reset-password/".$token) }}}'>
+    {{{ URL::to("user/reset-password/".$token) }}}
 </a>
 
 <p>{{ Lang::get('confide::confide.email.password_reset.farewell') }}</p>


### PR DESCRIPTION
AFAIK controllers cannot have actions separated with underscore so I replaced with a dash instead to allow for possibility of using something like 
public function getResetPassword( $token )

Ideally I think it would be just user/reset instead of user/reset-password
