### PR TITLE
Break the md5 hash

### DIFF
--- a/src/Zizaco/Confide/ConfideUser.php
+++ b/src/Zizaco/Confide/ConfideUser.php
@@ -168,7 +168,7 @@ class ConfideUser extends Ardent implements UserInterface {
     {
         if ( empty($this->id) )
         {
-            $this->confirmation_code = md5(microtime().static::$app['config']->get('app.key'));
+            $this->confirmation_code = substr(md5(microtime().static::$app['config']->get('app.key')),-8);
         }
 
         /*


### PR DESCRIPTION
Otherwise the md5 string can be decrypted and the application string is reveled. Which is a security concern.
