### PR TITLE
Updated URL in Reset Password View

### DIFF
--- a/src/views/emails/passwordreset.blade.php
+++ b/src/views/emails/passwordreset.blade.php
@@ -3,8 +3,8 @@
 <p>{{ Lang::get('confide::confide.email.password_reset.greetings', array( 'name' => $user->username)) }},</p>
 
 <p>{{ Lang::get('confide::confide.email.password_reset.body') }}</p>
-<a href='{{{ URL::to("user/reset_password/".$token) }}}'>
-    {{{ URL::to("user/reset_password/".$token) }}}
+<a href='{{{ URL::to("user/reset/".$token) }}}'>
+    {{{ URL::to("user/reset/".$token) }}}
 </a>
 
 <p>{{ Lang::get('confide::confide.email.password_reset.farewell') }}</p>


### PR DESCRIPTION
The URL::to() link in the reset password view should point to "user/reset" rather than "user/reset_password" - right?
