### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Access `http://yourapp/user/create` to create your first user. Check the `app/ro
 
 **Optional steps:**
 
-1. Use `Confide` facade to dump login and signup forms easly with `makeLoginForm()` and `makeSignupForm()`. You can render the forms within your views by doing `{{{ Confide::makeLoginForm()->render() }}}`.
+1. Use `Confide` facade to dump login and signup forms easly with `makeLoginForm()` and `makeSignupForm()`. You can render the forms within your views by doing `{{ Confide::makeLoginForm()->render() }}`.
 2. Generate a controller with the template contained in Confide throught the artisan command `$ php artisan confide:controller`. If a controller with the same name exists it will **NOT** be overwritten.
 3. Generate routes matching the controller template throught the artisan command `$ php artisan confide:routes`. Your `routes.php` will **NOT** be overwritten.
 


### PR DESCRIPTION
I have this replacement view for the login form:

    @extends('layouts.master')
    
    @section('content')
    {{{ Confide::makeLoginForm()->render() }}}
    @stop

It looks like this in the html source:

![layout-confide](https://f.cloud.github.com/assets/661038/321518/fdb0a366-99e2-11e2-9140-f240241ac82d.png)

It looks like it's related to [this merge](https://github.com/laravel/framework/issues/206) in Laravel 4. Suprisingly, it works as expected with two brackets instead:

    {{ Confide::makeLoginForm()->render() }}

Which seems to be just the opposite of what the comments say. So this just updates the docs to reflect what actually works (I updated my Laravel install just yesterday so I have the latest build).
