### PR TITLE
Prevent span.help-inline around signup errors

### DIFF
--- a/src/views/generators/controller.blade.php
+++ b/src/views/generators/controller.blade.php
@@ -54,7 +54,7 @@ class {{ $name }} extends BaseController {
         else
         {
             // Get validation errors (see Ardent package)
-            $error = ${{ lcfirst(Config::get('auth.model')) }}->errors()->all();
+            $error = ${{ lcfirst(Config::get('auth.model')) }}->errors()->all(':message');
 
             @if (! $restful)
             return Redirect::action('{{ $name }}@create')


### PR DESCRIPTION
In the _login view_ an error looks like this:
`<div class="alert alert-error">Incorrect username, email or password.</div>`
In the _register view_ it looks like this:
`<div class="alert alert-error"><span class="help-inline">The email field is required.</span></div>`
This was making my errors look weird.

This pull removes any default error wrappers to be more consistent with how the Login form displays error text.
