### PR TITLE
Added configuration setting and code to change the signup cache time

### DIFF
--- a/src/Zizaco/Confide/ConfideUser.php
+++ b/src/Zizaco/Confide/ConfideUser.php
@@ -177,7 +177,7 @@ class ConfideUser extends Ardent implements UserInterface {
 
         if(! $duplicated)
         {
-            return $this->real_save( $rules, $customMessages, $options, $beforeSave, $afterSave );    
+            return $this->real_save( $rules, $customMessages, $options, $beforeSave, $afterSave );
         }
         else
         {
@@ -234,8 +234,12 @@ class ConfideUser extends Ardent implements UserInterface {
 
             $this->sendEmail( 'confide::confide.email.account_confirmation.subject', $view, array('user' => $this) );
 
-            // Save in cache that the email has been sent. Will last for two hours
-            static::$app['cache']->put('confirmation_email_'.$this->_id, true, 120);
+            // Save in cache that the email has been sent.
+            $signup_cache = (int)static::$app['config']->get('confide::signup_cache');
+            if ($signup_cache !== 0)
+            {
+                static::$app['cache']->put('confirmation_email_'.$this->_id, true, $signup_cache);
+            }
         }
 
         return true;
@@ -354,7 +358,7 @@ class ConfideUser extends Ardent implements UserInterface {
 
     /**
      * [Deprecated]
-     * 
+     *
      * @deprecated
      */
     public function getUpdateRules()
@@ -364,7 +368,7 @@ class ConfideUser extends Ardent implements UserInterface {
 
     /**
      * [Deprecated] Parses the two given users and compares the unique fields.
-     * 
+     *
      * @deprecated
      * @param $oldUser
      * @param $updatedUser
@@ -392,7 +396,7 @@ class ConfideUser extends Ardent implements UserInterface {
 
     /**
      * [Deprecated]
-     * 
+     *
      * @deprecated
      */
     public function getRules()
@@ -402,7 +406,7 @@ class ConfideUser extends Ardent implements UserInterface {
 
     /**
      * [Deprecated]
-     * 
+     *
      * @deprecated
      */
     public function setUpdateRules($set)
@@ -427,7 +431,7 @@ class ConfideUser extends Ardent implements UserInterface {
     /**
      * [Deprecated] Checks if an user exists by it's credentials. Perform a 'where' within
      * the fields contained in the $identityColumns.
-     * 
+     *
      * @deprecated Use ConfideRepository getUserByIdentity instead.
      * @param  array $credentials      An array containing the attributes to search for
      * @param  mixed $identityColumns  Array of attribute names or string (for one atribute)
@@ -447,7 +451,7 @@ class ConfideUser extends Ardent implements UserInterface {
     /**
      * [Deprecated] Checks if an user is confirmed by it's credentials. Perform a 'where' within
      * the fields contained in the $identityColumns.
-     * 
+     *
      * @deprecated Use ConfideRepository getUserByIdentity instead.
      * @param  array $credentials      An array containing the attributes to search for
      * @param  mixed $identityColumns  Array of attribute names or string (for one atribute)

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -8,7 +8,7 @@ return array(
     |--------------------------------------------------------------------------
     |
     | Defines how many login failed tries may be done within
-    | two minutes. 
+    | two minutes.
     |
     */
 
@@ -61,4 +61,19 @@ return array(
     'email_reset_password' =>       'confide::emails.passwordreset', // with $user and $token.
     'email_account_confirmation' => 'confide::emails.confirm', // with $user
 
+    /*
+    |--------------------------------------------------------------------------
+    | Signup (create) Cache
+    |--------------------------------------------------------------------------
+    |
+    | By default you will only can only register once every 2 hours
+    | (120 minutes) because you are not able to receive a registration
+    | email more often then that.
+    |
+    | You can adjust that limitation here, set to 0 for no caching.
+    | Time is in minutes.
+    |
+    |
+    */
+    'signup_cache' => 120,
 );


### PR DESCRIPTION
Not sure what the intention of the cache is currently, my guess is it will (or could) act as a means of resending the account confirmation email.  It is also a good means of preventing spam account creation.

With that said, I needed to manually do some testing and wanted to create multiple accounts quickly.  Adding this configuration option allowed me to do that, possibly it will help someone else as well.
