### PR TITLE
Update to real_save's "sidestep of validation"

### DIFF
--- a/src/Zizaco/Confide/ConfideUser.php
+++ b/src/Zizaco/Confide/ConfideUser.php
@@ -272,10 +272,10 @@ class ConfideUser extends Ardent implements UserInterface {
              * This will make sure that a non modified password
              * will not trigger validation error.
              */
-            if( empty($rules) && $this->password == $this->getOriginal('password') )
+            if( isset($rules['password']) && $this->password == $this->getOriginal('password') )
             {
-                $rules = static::$rules;
-                $rules['password'] = 'required';
+                unset($rules['password']);
+                unset($rules['password_confirmation']);
             }
 
             return parent::save( $rules, $customMessages, $options, $beforeSave, $afterSave );


### PR DESCRIPTION
Hi Guys

I had a look at andrew13's postEdit in the great Laravel-4-Bootstrap-Starter site (https://github.com/andrew13/Laravel-4-Bootstrap-Starter-Site/blob/master/app/controllers/admin/AdminUsersController.php#L169) 

The postEdit seemed to have way too much logic for handling the password and password confirmation.

I simplified the code to

```
 public function postEdit($user)
    {

            $user->username = Input::get('username');
            $user->email = Input::get('email');

            if (Input::get('password'))
            {
                $user->password = Input::get('password');
                $user->password_confirmation = Input::get('password_confirmation');
            }

            $user->confirmed = Input::get('confirm');

            $user->amend();

        $error = $user->errors()->all();

        if(empty($error)) {
            // Redirect to the new user page
            return Redirect::to('edt/users/' . $user->id . '/edit')->with('success', Lang::get('admin/users/messages.edit.success'));
        } else {
                return Redirect::to('edt/users/' . $user->id . '/edit')->withErrors($error);
        }
    }

```

but this didn't quite work.

On close inspection I found an if statement checking if $rules are empty in line 275 of ConfideUser.php. Basically $rules are passed all the time meaning this IF would never fire. 

In this pull request I took the other route, instead of making a new set of rules, I simply delete the "password" rule from a pre-exiting set of rules.

With this change the code above runs correctly, ie. when the user enters a password, it is changes, but if he leaves it empty, it will stay the same without a validation error.

I also ran the PHPunit tests for Confide, all OK.
