### PR TITLE
Column not found: 'password_confirmation'

### DIFF
--- a/src/Zizaco/Confide/ConfideUser.php
+++ b/src/Zizaco/Confide/ConfideUser.php
@@ -51,7 +51,7 @@ class ConfideUser extends Ardent implements UserInterface {
         'username' => 'required|alpha_dash|unique:users',
         'email' => 'required|email|unique:users',
         'password' => 'required|between:4,11|confirmed',
-        'password_confirmation' => 'between:4,11',
+        'confirmation_code' => 'between:4,11',
     );
 
     /**
@@ -63,7 +63,7 @@ class ConfideUser extends Ardent implements UserInterface {
         'username' => 'required|alpha_dash',
         'email' => 'required|email',
         'password' => 'between:4,11|confirmed',
-        'password_confirmation' => 'between:4,11',
+        'confirmation_code' => 'between:4,11',
     );
 
     /**
@@ -143,7 +143,7 @@ class ConfideUser extends Ardent implements UserInterface {
     public function resetPassword( $params )
     {
         $password = array_get($params, 'password', '');
-        $passwordConfirmation = array_get($params, 'password_confirmation', '');
+        $passwordConfirmation = array_get($params, 'confirmation_code', '');
 
         if ( $password == $passwordConfirmation )
         {
@@ -207,12 +207,12 @@ class ConfideUser extends Ardent implements UserInterface {
         }
 
         /*
-         * Remove password_confirmation field before save to
+         * Remove confirmation_code field before save to
          * database.
          */
-        if ( isset($user->password_confirmation) )
+        if ( isset($user->confirmation_code) )
         {
-            unset( $user->password_confirmation );
+            unset( $user->confirmation_code );
         }
 
         return true;

--- a/src/lang/ca_ES/confide.php
+++ b/src/lang/ca_ES/confide.php
@@ -4,7 +4,7 @@ return array(
 
     'username' => 'Nom d\'usuari',
     'password' => 'Contrasenya',
-    'password_confirmation' => 'Confirmació de la contrasenya',
+    'confirmation_code' => 'Confirmació de la contrasenya',
     'e_mail' => 'Email',
     'username_e_mail' => 'Nom d\'usuari o email',
 

--- a/src/lang/en/confide.php
+++ b/src/lang/en/confide.php
@@ -4,7 +4,7 @@ return array(
 
     'username' => 'Username',
     'password' => 'Password',
-    'password_confirmation' => 'Confirm Password',
+    'confirmation_code' => 'Confirm Password',
     'e_mail' => 'Email',
     'username_e_mail' => 'Username or Email',
 

--- a/src/lang/fr/confide.php
+++ b/src/lang/fr/confide.php
@@ -4,7 +4,7 @@ return array(
 
     'username' => 'Utilisateur',
     'password' => 'Mot de passe',
-    'password_confirmation' => 'Confirmez le mot de passe',
+    'confirmation_code' => 'Confirmez le mot de passe',
     'e_mail' => 'Email',
     'username_e_mail' => "Nom d'utilisateur ou Email",
 

--- a/src/lang/pt/confide.php
+++ b/src/lang/pt/confide.php
@@ -4,7 +4,7 @@ return array(
 
     'username' => 'Nome de Usuário',
     'password' => 'Senha',
-    'password_confirmation' => 'Confirmar senha',
+    'confirmation_code' => 'Confirmar senha',
     'e_mail' => 'Email',
     'username_e_mail' => 'Email ou Usuário',
 

--- a/src/views/generators/controller.blade.php
+++ b/src/views/generators/controller.blade.php
@@ -36,7 +36,7 @@ class {{ $name }} extends BaseController {
         // The password confirmation will be removed from model
         // before saving. This field will be used in Ardent's
         // auto validation.
-        ${{ lcfirst(Config::get('auth.model')) }}->password_confirmation = Input::get( 'password_confirmation' );
+        ${{ lcfirst(Config::get('auth.model')) }}->confirmation_code = Input::get( 'confirmation_code' );
 
         // Save if valid. Password field will be hashed before save
         ${{ lcfirst(Config::get('auth.model')) }}->save();
@@ -227,7 +227,7 @@ class {{ $name }} extends BaseController {
         $input = array(
             'token'=>Input::get( 'token' ),
             'password'=>Input::get( 'password' ),
-            'password_confirmation'=>Input::get( 'password_confirmation' ),
+            'confirmation_code'=>Input::get( 'confirmation_code' ),
         );
 
         // By passing an array with the token, password and confirmation

--- a/src/views/reset_password.blade.php
+++ b/src/views/reset_password.blade.php
@@ -5,8 +5,8 @@
     <label for="password">{{{ Lang::get('confide::confide.password') }}}</label>
     <input placeholder="{{{ Lang::get('confide::confide.password') }}}" type="password" name="password" id="password">
 
-    <label for="password_confirmation">{{{ Lang::get('confide::confide.password_confirmation') }}}</label>
-    <input placeholder="{{{ Lang::get('confide::confide.password_confirmation') }}}" type="password" name="password_confirmation" id="password_confirmation">
+    <label for="confirmation_code">{{{ Lang::get('confide::confide.confirmation_code') }}}</label>
+    <input placeholder="{{{ Lang::get('confide::confide.confirmation_code') }}}" type="password" name="confirmation_code" id="confirmation_code">
 
     @if ( Session::get('error') )
         <div class="alert alert-error">{{{ Session::get('error') }}}</div>

--- a/src/views/signup.blade.php
+++ b/src/views/signup.blade.php
@@ -10,8 +10,8 @@
         <label for="password">{{{ Lang::get('confide::confide.password') }}}</label>
         <input placeholder="{{{ Lang::get('confide::confide.password') }}}" type="password" name="password" id="password">
 
-        <label for="password_confirmation">{{{ Lang::get('confide::confide.password_confirmation') }}}</label>
-        <input placeholder="{{{ Lang::get('confide::confide.password_confirmation') }}}" type="password" name="password_confirmation" id="password_confirmation">
+        <label for="confirmation_code">{{{ Lang::get('confide::confide.confirmation_code') }}}</label>
+        <input placeholder="{{{ Lang::get('confide::confide.confirmation_code') }}}" type="password" name="confirmation_code" id="confirmation_code">
 
         @if ( Session::get('error') )
             <div class="alert alert-error">

--- a/tests/ConfideUserTest.php
+++ b/tests/ConfideUserTest.php
@@ -95,7 +95,7 @@ class ConfideUserTest extends PHPUnit_Framework_TestCase {
         $credentials = array(
             'email'=>'mail@sample.com',
             'password'=>'987987',
-            'password_confirmation'=>'987987'
+            'confirmation_code'=>'987987'
         );
 
         // Should call changePassword of the repository


### PR DESCRIPTION
When trying to create a new user using the form in `user/create` route, I get the following error:

```
SQLSTATE[42S22]: Column not found: 1054
Unknown column 'password_confirmation' in 'field list'
(SQL: insert into `users`
(`username`, `email`, `password`, `password_confirmation`,
`updated_at`, `created_at`) values...
```

I used the artisan command `confide:migration` to generate the User table migration and the name of the field for confirmation code is `confirmation_code`. However, in `ConfideUser.php` the same field is designated as `password_confirmation`.
