### PR TITLE
Bruteforce throttling vulnerability

### DIFF
--- a/src/Zizaco/Confide/Confide.php
+++ b/src/Zizaco/Confide/Confide.php
@@ -289,9 +289,7 @@ class Confide
     protected function attemptCacheKey( $credentials )
     {
         return 'confide_flogin_attempt_'
-            .$this->app['request']->server('REMOTE_ADDR')
-            .$this->app['request']->server('HTTP_X_FORWARDED_FOR')
-            .$credentials['email'];
+            .$this->app['request']->server('REMOTE_ADDR');
     }
 
     /**


### PR DESCRIPTION
Using HTTP_X_FORWARDED_FOR in the key is useless because the client can set a random X-Forwarded-For and bypass throttling.
Secondly using email in the key is useless too because there is little chance the same IP needs to access multiples accounts and have lost its passwords for all its accounts.

The rare case when one IP need to access multiple accounts is when it's behind a reverse proxy. In this case the 'HTTP_X_FORWARDED_FOR' should be used if it's properly set by the reverse proxy and not overridable. 

Most of the time web application aren't behind reverse proxy so it's safe to only check REMOTE_ADDR
