### PR TITLE
Add Laravel 4.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*",
-        "laravelbook/ardent": "2.1.x"
+        "laravelbook/ardent": "dev-master"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",


### PR DESCRIPTION
Replaces references to illuminate/ components with `4.*`.

Also uses dev-master for Ardent (the most recent tag uses `4.0.x` references, however a later commit on master changed them to `4.*`).
