### PR TITLE
Fixed issue with empty credentials selecting the first user. 

### DIFF
--- a/src/Zizaco/Confide/ConfideEloquentRepository.php
+++ b/src/Zizaco/Confide/ConfideEloquentRepository.php
@@ -98,6 +98,11 @@ class ConfideEloquentRepository implements ConfideRepository
      */
     public function getUserByIdentity( $credentials, $identityColumns = array('email') )
     {
+        if(empty($credentials))
+        {
+            return null;
+        }
+
         $identityColumns = (array)$identityColumns;
 
         $user = $this->model();

--- a/tests/ConfideEloquentRepositoryTest.php
+++ b/tests/ConfideEloquentRepositoryTest.php
@@ -157,6 +157,11 @@ class ConfideEloquentRepositoryTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals(
             $confide_user, $this->repo->getUserByIdentity( $values, 'username' )
         );
+
+        // When passing empty credentials should return null
+        $this->assertEquals(
+            null, $this->repo->getUserByIdentity( array() )
+        );
     }
 
     public function testShouldGetPasswordRemindersCountByToken()


### PR DESCRIPTION
This might be a security issue (although it is likely fine), but the big issue is when using multiple test accounts with the same password and getting logged in as the wrong one when credentials aren't getting passed properly.
