### PR TITLE
Switched from Ardent 2.3.x to 2.4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.1.x",
-        "laravelbook/ardent": "2.3.x"
+        "laravelbook/ardent": "2.4.x"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",


### PR DESCRIPTION
The latest Ardent seems to work fine. The changes between these two version are trivial. Make sure to pull at Entrust as well to prevent collision with the update.
