### PR TITLE
Allow passwords longer than 11 characters

### DIFF
--- a/src/Zizaco/Confide/ConfideUser.php
+++ b/src/Zizaco/Confide/ConfideUser.php
@@ -50,8 +50,8 @@ class ConfideUser extends Ardent implements UserInterface {
     public static $rules = array(
         'username' => 'required|alpha_dash|unique:users',
         'email' => 'required|email|unique:users',
-        'password' => 'required|between:4,11|confirmed',
-        'password_confirmation' => 'between:4,11',
+        'password' => 'required|min:4|confirmed',
+        'password_confirmation' => 'min:4',
     );
 
     /**
@@ -327,8 +327,8 @@ class ConfideUser extends Ardent implements UserInterface {
     protected $updateRules = array(
         'username' => 'required|alpha_dash',
         'email' => 'required|email',
-        'password' => 'between:4,11|confirmed',
-        'password_confirmation' => 'between:4,11',
+        'password' => 'min:4|confirmed',
+        'password_confirmation' => 'min:4',
     );
 
     /**


### PR DESCRIPTION
It is poor security practice to set a maximum length on a password, especially one as low at 11 characters. I kept the minimum at 4 characters just to not break backwards compatibility, but it should really be a minimum of 8 characters these days.
