### PR TITLE
Switch back to laravelbook/ardent : dev master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,10 @@
             "homepage": "http://www.andrewelkins.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/Zizaco/ardent.git"
-        }
-    ],
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.1.x",
-        "laravelbook/ardent": "dev-has-session-fix"
+        "laravelbook/ardent": "dev-master"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",


### PR DESCRIPTION
Remove 'laravelbook/ardent' workaround as master package has been updated.
