### PR TITLE
Support for 4.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x",
+        "illuminate/support": "~4.1",
         "laravelbook/ardent": "dev-master"
     },
     "require-dev": {
         "mockery/mockery": "0.7.2",
-        "illuminate/database": "4.1.x",
-        "illuminate/auth": "4.1.x"
+        "illuminate/database": "~4.1",
+        "illuminate/auth": "~4.1"
     },
     "suggest": {
         "zizaco/entrust":"add Role-based Permissions to Laravel 4"


### PR DESCRIPTION
The requirement is very strict now for just Laravel 4.1. With my change you also can use your package with Laravel 4.2, even when that one isn't officially released. Hope you'll merge it, will help me out a lot.
