### PR TITLE
Added "remember_token" column to the users table

### DIFF
--- a/src/migrations/2013_01_13_172956_confide_setup_users_table.php
+++ b/src/migrations/2013_01_13_172956_confide_setup_users_table.php
@@ -20,6 +20,7 @@ class ConfideSetupUsersTable extends Migration {
 		    $table->string('password');
 		    $table->string('confirmation_code');
 		    $table->boolean('confirmed')->default(false);
+		    $table->string('remember_token')->nullable();
 		    $table->timestamps();
 		});
 	}


### PR DESCRIPTION
The "Remember Me" functionality does not work on a fresh install of Confide as the migrations table does not contain the "remember_token" column. With the proposed change, the token value for the "remember me" session can be properly saved.
