### PR TITLE
Remember Token saving bug

### DIFF
--- a/src/Zizaco/Confide/ConfideUser.php
+++ b/src/Zizaco/Confide/ConfideUser.php
@@ -197,6 +197,16 @@ class ConfideUser extends Ardent implements UserInterface {
     {
         $duplicated = false;
 
+        /*
+         * When EloquentUserProvider call updateRememberToken 
+         * it doesn't retrieve rules, so validation on Ardent fails
+         */
+        if (!empty($this->remember_token) && empty($rules))
+        {
+            $rules = static::$rules;
+            $rules = array_diff(array_keys($rules), array('password_confirmation'));
+        }
+
         if(! $this->id)
         {
             $duplicated = static::$app['confide.repository']->userExists( $this );


### PR DESCRIPTION
When trying to save a RememberToken on EloquentUserProvider the
function updateRememberToken() call $user->save() without parameters,
than validation on Ardent fails because of password_confirmation rules
is in the rules array but it isn’t set in the object user
