### PR TITLE
Update ConfideUser.php

### DIFF
--- a/src/Zizaco/Confide/ConfideUser.php
+++ b/src/Zizaco/Confide/ConfideUser.php
@@ -136,7 +136,7 @@ class ConfideUser extends Ardent implements UserInterface {
             'password' => static::$rules['password'],
             'password_confirmation' => static::$rules['password_confirmation'],
         );
-        $validationResult = static::$app['confide.repository']->validate($passwordValidators);
+        $validationResult = static::$app['confide.repository']->validate($params, $passwordValidators);
 
         if ( $validationResult )
         {


### PR DESCRIPTION
Fixed bug for invalid reset password: validate method must have two input. Simple solution, I just edit one line of code.
