### PR TITLE
fixed ConfideUser, to support user-models with non-standard key-columns

### DIFF
--- a/src/Zizaco/Confide/ConfideUser.php
+++ b/src/Zizaco/Confide/ConfideUser.php
@@ -215,7 +215,7 @@ class ConfideUser extends Ardent implements UserInterface {
             $rules = array_diff(array_keys($rules), array('password_confirmation'));
         }
 
-        if(! $this->id)
+        if(! $this->getKey())
         {
             $duplicated = static::$app['confide.repository']->userExists( $this );
         }
@@ -245,7 +245,8 @@ class ConfideUser extends Ardent implements UserInterface {
      */
     public function beforeSave($forced = false)
     {
-        if ( empty($this->id) )
+        $id=$this->getKey();
+        if ( empty($id) )
         {
             $this->confirmation_code = md5( uniqid(mt_rand(), true) );
         }
@@ -273,7 +274,7 @@ class ConfideUser extends Ardent implements UserInterface {
      */
     public function afterSave($success=true, $forced = false)
     {
-        if (! $this->confirmed && ! static::$app['cache']->get('confirmation_email_'.$this->id) )
+        if (! $this->confirmed && ! static::$app['cache']->get('confirmation_email_'.$this->getKey()) )
         {
             // on behalf or the config file we should send and email or not
             if (static::$app['config']->get('confide::signup_email') == true)
@@ -285,7 +286,7 @@ class ConfideUser extends Ardent implements UserInterface {
             $signup_cache = (int)static::$app['config']->get('confide::signup_cache');
             if ($signup_cache !== 0)
             {
-                static::$app['cache']->put('confirmation_email_'.$this->id, true, $signup_cache);
+                static::$app['cache']->put('confirmation_email_'.$this->getKey(), true, $signup_cache);
             }
         }
 

--- a/src/views/generators/controller.blade.php
+++ b/src/views/generators/controller.blade.php
@@ -41,14 +41,14 @@ class {{ $name }} extends BaseController {
         // Save if valid. Password field will be hashed before save
         ${{ lcfirst(Config::get('auth.model')) }}->save();
 
-        if ( ${{ lcfirst(Config::get('auth.model')) }}->id )
+        if ( ${{ lcfirst(Config::get('auth.model')) }}->getKey() )
         {
             @if ( Config::get('confide::signup_confirm') && Config::get('confide::signup_email'))
-            $notice = Lang::get('confide::confide.alerts.account_created') . ' ' . Lang::get('confide::confide.alerts.instructions_sent'); 
+            $notice = Lang::get('confide::confide.alerts.account_created') . ' ' . Lang::get('confide::confide.alerts.instructions_sent');
             @else
-            $notice = Lang::get('confide::confide.alerts.account_created'); 
+            $notice = Lang::get('confide::confide.alerts.account_created');
             @endif
-        
+
             // Redirect with success message, You may replace "Lang::get(..." for your custom message.
             @if (! $restful)
             return Redirect::action('{{ $name }}@login')
@@ -80,7 +80,7 @@ class {{ $name }} extends BaseController {
     {
         if( Confide::user() )
         {
-            // If user is logged, redirect to internal 
+            // If user is logged, redirect to internal
             // page, change it to '/admin', '/dashboard' or something
             return Redirect::to('/');
         }
@@ -107,7 +107,7 @@ class {{ $name }} extends BaseController {
         // with the second parameter as true.
         // logAttempt will check if the 'email' perhaps is the username.
         // Get the value from the config file instead of changing the controller
-        if ( Confide::logAttempt( $input, Config::get('confide::signup_confirm') ) ) 
+        if ( Confide::logAttempt( $input, Config::get('confide::signup_confirm') ) )
         {
             // Redirect the user to the URL they were trying to access before
             // caught by the authentication filter IE Redirect::guest('user/login').
@@ -263,7 +263,7 @@ class {{ $name }} extends BaseController {
     public function {{ (! $restful) ? 'logout' : 'getLogout' }}()
     {
         Confide::logout();
-        
+
         return Redirect::to('/');
     }
 


### PR DESCRIPTION
when User-Models use a different name than 'id' as their unique key, ConfideUser did
not work correctly.

this patch replaces calls to $this->id with $this->getKey()
