### PR TITLE
Added confide.connection config option for specifying database connection

### DIFF
--- a/src/Zizaco/Confide/EloquentPasswordService.php
+++ b/src/Zizaco/Confide/EloquentPasswordService.php
@@ -38,8 +38,9 @@ class EloquentPasswordService implements PasswordServiceInterface
      */
     public function requestChangePassword(RemindableInterface $user)
     {
-        $email = $user->getReminderEmail();
-        $token = $this->generateToken();
+        $email  = $user->getReminderEmail();
+        $token  = $this->generateToken();
+        $config = $this->app['config'];
 
         $values = array(
             'email'=> $email,
@@ -48,7 +49,7 @@ class EloquentPasswordService implements PasswordServiceInterface
         );
 
         $this->app['db']
-            ->connection()
+            ->connection($config->get('confide::connection'))
             ->table('password_reminders')
             ->insert($values);
 
@@ -65,8 +66,9 @@ class EloquentPasswordService implements PasswordServiceInterface
      */
     public function getEmailByToken($token)
     {
-        $email = $this->app['db']
-            ->connection()
+        $config = $this->app['config'];
+        $email  = $this->app['db']
+            ->connection($config->get('confide::connection'))
             ->table('password_reminders')
             ->select('email')->where('token','=',$token)
             ->first();

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,6 +4,19 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | Defines which database connection to use when 
+    | looking for the users table. The default null value uses the default connection.
+    | To use a connection besides the default define it like:
+    | 'connection' => 'myConnection'
+    |
+    */
+    'connection' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Login Throttle
     |--------------------------------------------------------------------------
     |

--- a/tests/Zizaco/Confide/EloquentPasswordServiceTest.php
+++ b/tests/Zizaco/Confide/EloquentPasswordServiceTest.php
@@ -24,7 +24,7 @@ class EloquentPasswordServiceTest extends PHPUnit_Framework_TestCase
         m::close();
     }
 
-    public function testSouldRequestChangePassword()
+    public function testShouldRequestChangePassword()
     {
         /*
         |------------------------------------------------------------
@@ -35,13 +35,15 @@ class EloquentPasswordServiceTest extends PHPUnit_Framework_TestCase
         $userEmail = 'someone@somewhere.com';
         $generatedToken = '123456789';
 
-        $user = m::mock('Illuminate\Auth\Reminders\RemindableInterface');
+        $user        = m::mock('Illuminate\Auth\Reminders\RemindableInterface');
         $passService = m::mock('Zizaco\Confide\EloquentPasswordService[generateToken,sendEmail]',[]);
-        $db = m::mock('connection');
+        $db          = m::mock('connection');
+        $config      = m::mock('Config');
 
         $passService->shouldAllowMockingProtectedMethods();
 
-        $passService->app['db'] = $db;
+        $passService->app['db']     = $db;
+        $passService->app['config'] = $config;
 
         /*
         |------------------------------------------------------------
@@ -87,6 +89,10 @@ class EloquentPasswordServiceTest extends PHPUnit_Framework_TestCase
             ->once()
             ->andReturn(true);
 
+        $config->shouldReceive('get')
+            ->once()->with('confide::connection')
+            ->andReturn('connection');
+
         /*
         |------------------------------------------------------------
         | Assertion
@@ -105,13 +111,16 @@ class EloquentPasswordServiceTest extends PHPUnit_Framework_TestCase
         | Set
         |------------------------------------------------------------
         */
-        $userEmail = 'someone@somewhere.com';
-        $token = '123456789';
+        $userEmail   = 'someone@somewhere.com';
+        $token       = '123456789';
         $passService = m::mock('Zizaco\Confide\EloquentPasswordService');
-        $passService->shouldAllowMockingProtectedMethods();
-        $db = m::mock('connection');
+        $db          = m::mock('connection');
+        $config      = m::mock('Config');
 
-        $passService->app['db'] = $db;
+        $passService->shouldAllowMockingProtectedMethods();
+
+        $passService->app['db']     = $db;
+        $passService->app['config'] = $config;
 
         /*
         |------------------------------------------------------------
@@ -152,6 +161,10 @@ class EloquentPasswordServiceTest extends PHPUnit_Framework_TestCase
         $db->shouldReceive('first')
             ->once()
             ->andReturn(['email' => $userEmail]);
+
+        $config->shouldReceive('get')
+            ->once()->with('confide::connection')
+            ->andReturn('connection');
 
         /*
         |------------------------------------------------------------


### PR DESCRIPTION
After looking further into #313 I realized the `connection()` method is only used twice in the repo it seems. Thanks for consideration, cheers!
