### PR TITLE
Improve default UserValidator behavior[4.0.0 beta 2]

### DIFF
--- a/tests/Zizaco/Confide/UserValidatorTest.php
+++ b/tests/Zizaco/Confide/UserValidatorTest.php
@@ -175,14 +175,14 @@ class UserValidatorTest extends PHPUnit_Framework_TestCase
             ->andReturn($userD->id);
 
         $repo->shouldReceive('getUserByIdentity')
-            ->andReturnUsing(function($user) use ($userB, $userC) {
-                if ($user['email'] == $userB->email) return $userB;
-                if ($user['email'] == $userC->email) return $userC;
+          ->andReturnUsing(function($user) use ($userB, $userC) {
+              if (isset($user['email']) && $user['email'] == $userB->email) return $userB;
+              if (isset($user['email']) && $user['email'] == $userC->email) return $userC;
             });
 
         $validator->shouldReceive('attachErrorMsg')
             ->atLeast(1)
-            ->with(m::any(), 'confide::confide.alerts.duplicated_credentials');
+            ->with(m::any(), 'confide::confide.alerts.duplicated_credentials', 'email');
 
         /*
         |------------------------------------------------------------


### PR DESCRIPTION
Hi, some features not added to #311:
- Reordered validations – since a `validateIsUnique` or `validatePassword` message should not be `key` overwritten by `validateAttributes` as this last one is probably a less relevant error message
- Now all validations are called even if one of them fails.. So all validation messages are sent at once.
- `validateIsUnique` method now sends key to `attachErrorMsg` and also check for errors on each `$identity` field at once

:beers:
