### PR TITLE
[Master] Password verification

### DIFF
--- a/src/Zizaco/Confide/UserValidator.php
+++ b/src/Zizaco/Confide/UserValidator.php
@@ -83,7 +83,7 @@ class UserValidator implements UserValidatorInterface {
         $hash = App::make('hash');
 
         if($user->getOriginal('password') != $user->password) {
-            if ($user->password == $user->password_confirmation) {
+            if ($user->password === $user->password_confirmation) {
 
                 // Hashes password and unset password_confirmation field
                 $user->password = $hash->make($user->password);


### PR DESCRIPTION
With `==` is a little bit dangerous. Example:

``` php
var_dump( "1e3" == "1000" ); // true
```
