### PR TITLE
[3.2] Added a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml export-ignore
+/README.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /vendor
 composer.lock
-.DS_Store


### PR DESCRIPTION
This is so when people are installing this through composer, they only get the required source files. This saves disk space for the user, and saves github's bandwidth.
