### PR TITLE
[4.0] Added a .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+/tests export-ignore
+/.coveralls.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpunit.xml export-ignore
+/phpunit.xml.dist export-ignore
+/README.md export-ignore


### PR DESCRIPTION
This is so when people are installing this through composer, they only get the required source files. This saves disk space for the user, and saves github's bandwidth.
