### PR TITLE
Add dev flag in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ to be confirmed to be able to login to the website._
 
 In the `require` key of `composer.json` file add the following
 
-    "zizaco/confide": "~4.0"
+    "zizaco/confide": "~4.0@dev"
 
 Run the Composer update comand
 


### PR DESCRIPTION
People seem unaware of this even existing, which is quite odd! Let's give them a hand, and add it to the readme. They can always remove it to get a stable tag.
