### PR TITLE
ConfideUserTest: match Eloquent method name change

### DIFF
--- a/tests/Confide/ConfideUserTest.php
+++ b/tests/Confide/ConfideUserTest.php
@@ -183,7 +183,7 @@ class ConfideUserTest extends PHPUnit_Framework_TestCase
         | Set
         |------------------------------------------------------------
         */
-        $user = m::mock('Zizaco\Confide\_ConfideUserStub[isValid,save,newQueryWithDeleted]');
+        $user = m::mock('Zizaco\Confide\_ConfideUserStub[isValid,save,newQueryWithoutScopes]');
 
         /*
         |------------------------------------------------------------
@@ -199,7 +199,7 @@ class ConfideUserTest extends PHPUnit_Framework_TestCase
             ->andReturn(false); // If validation returns false
 
         // Throw an exception instead of actually saving the object
-        $user->shouldReceive('newQueryWithDeleted')
+        $user->shouldReceive('newQueryWithoutScopes')
             ->never()
             ->andReturnUsing(function () {
                 throw new \Exception('Saved in database');


### PR DESCRIPTION
This simply does on lines 186, 202 what commit 617e3aad did on lines
113, 129. The change `newQueryWithDeleted()` to `newQueryWithoutScopes()` occurred at the top of the `save()` method in Laravel's [Model.php](https://github.com/laravel/framework/blob/4.2/src/Illuminate/Database/Eloquent/Model.php).
