### PR TITLE
Use queues for sending emails

### DIFF
--- a/src/Confide/EloquentPasswordService.php
+++ b/src/Confide/EloquentPasswordService.php
@@ -157,7 +157,8 @@ class EloquentPasswordService implements PasswordServiceInterface
         $config = $this->app['config'];
         $lang   = $this->app['translator'];
 
-        $this->app['mailer']->queue(
+        $this->app['mailer']->queueOn(
+            $config->get('confide::email_queue'),
             $config->get('confide::email_reset_password'),
             compact('user', 'token'),
             function ($message) use ($user, $token, $lang) {

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -108,4 +108,15 @@ return array(
     'signup_email'      => true,
     'signup_confirm'    => true,
 
+    /*
+    |--------------------------------------------------------------------------
+    | E-Mail queue
+    |--------------------------------------------------------------------------
+    |
+    | Modify the line below to change which queue driver Confide uses to send
+    | e-mails.
+    |
+    */
+    'email_queue'      => 'sync',
+
 );

--- a/src/views/generators/controller.blade.php
+++ b/src/views/generators/controller.blade.php
@@ -43,7 +43,8 @@ class {{ $class }} extends Controller
         $user = $repo->signup(Input::all());
 
         if ($user->id) {
-            Mail::queue(
+            Mail::queueOn(
+                Config::get('confide::email_queue'),
                 Config::get('confide::email_account_confirmation'),
                 compact('user'),
                 function ($message) use ($user) {

--- a/tests/Confide/EloquentPasswordServiceTest.php
+++ b/tests/Confide/EloquentPasswordServiceTest.php
@@ -368,9 +368,9 @@ class EloquentPasswordServiceTest extends PHPUnit_Framework_TestCase
         $passService->shouldReceive('sendEmail')
             ->passthru();
 
-        $mailer->shouldReceive('queue')
-            ->once()->with('view.name', ['user'=>$user, 'token'=>$token], m::any())
-            ->andReturnUsing(function ($a, $b, $closure) use ($test, $user) {
+        $mailer->shouldReceive('queueOn')
+            ->once()->with('sync', 'view.name', ['user'=>$user, 'token'=>$token], m::any())
+            ->andReturnUsing(function ($q, $a, $b, $closure) use ($test, $user) {
                 $message = m::mock('Message');
 
                 $message->shouldReceive('to')
@@ -391,6 +391,10 @@ class EloquentPasswordServiceTest extends PHPUnit_Framework_TestCase
         $config->shouldReceive('get')
             ->once()->with('confide::email_reset_password')
             ->andReturn('view.name');
+
+        $config->shouldReceive('get')
+            ->once()->with('confide::email_queue')
+            ->andReturn('sync');
 
         /*
         |------------------------------------------------------------


### PR DESCRIPTION
Sending emails can be fairly slow, meaning people may want to use queues for it. Currently confide doesn't easily allow queues, but these changes will let confide automatically use queues if a developer has configured their application for them. If queues aren't set up, Laravel will just send the email like normal.

http://laravel.com/docs/mail#queueing-mail
