### PR TITLE
Can't Send Confirmation Email when Creating User

### DIFF
--- a/src/views/emails/confirm.blade.php
+++ b/src/views/emails/confirm.blade.php
@@ -1,10 +1,10 @@
 <h1>{{ Lang::get('confide::confide.email.account_confirmation.subject') }}</h1>
 
-<p>{{ Lang::get('confide::confide.email.account_confirmation.greetings', array('name' => $user->username)) }},</p>
+<p>{{ Lang::get('confide::confide.email.account_confirmation.greetings', array('name' => $user['username'])) }},</p>
 
 <p>{{ Lang::get('confide::confide.email.account_confirmation.body') }}</p>
-<a href='{{{ URL::to("users/confirm/{$user->confirmation_code}") }}}'>
-    {{{ URL::to("users/confirm/{$user->confirmation_code}") }}}
+<a href='{{{ URL::to("users/confirm/{$user['confirmation_code']}") }}}'>
+    {{{ URL::to("users/confirm/{$user['confirmation_code']}") }}}
 </a>
 
 <p>{{ Lang::get('confide::confide.email.account_confirmation.farewell') }}</p>

--- a/src/views/emails/passwordreset.blade.php
+++ b/src/views/emails/passwordreset.blade.php
@@ -1,6 +1,6 @@
 <h1>{{ Lang::get('confide::confide.email.password_reset.subject') }}</h1>
 
-<p>{{ Lang::get('confide::confide.email.password_reset.greetings', array( 'name' => $user->username)) }},</p>
+<p>{{ Lang::get('confide::confide.email.password_reset.greetings', array( 'name' => $user['username'])) }},</p>
 
 <p>{{ Lang::get('confide::confide.email.password_reset.body') }}</p>
 <a href='{{ URL::to('users/reset_password/'.$token) }}'>


### PR DESCRIPTION
When I create user with the default controller provided by confide I get following error:
#### Trying to get property of non-object (View: /Applications/MAMP/htdocs/ikollect/vendor/zizaco/confide/src/views/emails/confirm.blade.php)

which comes from the usage of `$user` as  object in the view and `$user` is an array
#### zizaco/confide/src/views/emails/confirm.blade.php:3

`<p><?php echo Lang::get('confide::confide.email.account_confirmation.greetings', array('name' => $user->username)); ?>,</p>`
#### app/controllers/UsersController.php:28-38

```
public function store()
{
    $repo = App::make('UserRepository');
    $user = $repo->signup(Input::all());

    if ($user->id) {
        Mail::queueOn(
            Config::get('confide::email_queue'),
            Config::get('confide::email_account_confirmation'),
```
#### `compact('user'),`

```
            function ($message) use ($user) {
                $message
                    ->to($user->email, $user->username)
```
