### PR TITLE
Update Controller redirect to new camelCase name

### DIFF
--- a/src/views/generators/controller.blade.php
+++ b/src/views/generators/controller.blade.php
@@ -191,7 +191,7 @@ class {{ $class }} extends Controller
                 ->with('notice', $notice_msg);
         } else {
             $error_msg = Lang::get('confide::confide.alerts.wrong_password_reset');
-            return Redirect::action('{{ $namespace ? $namespace.'\\' : '' }}{{ $class }}@reset_password', array('token'=>$input['token']))
+            return Redirect::action('{{ $namespace ? $namespace.'\\' : '' }}{{ $class }}@resetPassword', array('token'=>$input['token']))
                 ->withInput()
                 ->with('error', $error_msg);
         }


### PR DESCRIPTION
The redirect in postReset/doResetPassword generated controller action is pointing to, what I assume, is the old snake_case naming convention. Just a minor typo.
