### PR TITLE
Make sure `password_confirmation` is being removed

### DIFF
--- a/src/Confide/UserValidator.php
+++ b/src/Confide/UserValidator.php
@@ -90,9 +90,6 @@ class UserValidator implements UserValidatorInterface
 
                 // Hashes password and unset password_confirmation field
                 $user->password = $hash->make($user->password);
-                unset($user->password_confirmation);
-
-                return true;
             } else {
                 $this->attachErrorMsg(
                     $user,
@@ -102,6 +99,8 @@ class UserValidator implements UserValidatorInterface
                 return false;
             }
         }
+        
+        unset($user->password_confirmation);
 
         return true;
     }


### PR DESCRIPTION
We have a "password is optional because we have an invite system where users are invited and set up their account and password via invite link in email" type system and are running into the following issue:

Referencing these lines: https://github.com/Zizaco/confide/blob/4.0.0-rc.2/src/views/generators/repository.blade.php#L34,L37

Since Ardent is being removed, `password_confirmation` is _not_ being "auto removed" and I am getting an error trying to save a user:

> Unknown column 'password_confirmation'

Eloquent does _not_ auto remove that field.

If we follow it upstream, we see an attempt to remove the password manually here: https://github.com/Zizaco/confide/blob/4.0.0-rc.2/src%2FConfide%2FUserValidator.php#L93

But in this case, `$user->getOriginal('password') != $user->password` appears to be always false, so we never get in there.

This proposal will make it so `password_confirmation` will always be removed as long as that function is being called (and there isn't an error) (but I would argue this still isn't a great solution... what if someone overrides their own `validatePassword` function? They just need to know they need to remove that one thing?)
