### PR TITLE
Configurable password reminder table

### DIFF
--- a/src/Confide/EloquentPasswordService.php
+++ b/src/Confide/EloquentPasswordService.php
@@ -1,7 +1,6 @@
 <?php namespace Zizaco\Confide;
 
 use Illuminate\Auth\Reminders\RemindableInterface;
-use Illuminate\Support\Facades\Config;
 
 /**
  * A service that abstracts all user password management related methods.

--- a/tests/Confide/EloquentPasswordServiceTest.php
+++ b/tests/Confide/EloquentPasswordServiceTest.php
@@ -2,7 +2,6 @@
 
 use Mockery as m;
 use PHPUnit_Framework_TestCase;
-use Illuminate\Auth\Reminders\RemindableInterface;
 
 class EloquentPasswordServiceTest extends PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
Vanilla Laravel ships with a configurable password_reminders table (in app/config/auth.php). In Confide this table name seemed to be hardcoded. Since my database has its own naming scheme I had a need to make Confide respect the reminder config.

I've thrown in some unittests as well. :)
