### PR TITLE
Fixed bug when parseIdentity was returning null instead of string when received string

### DIFF
--- a/src/Confide/CacheLoginThrottleService.php
+++ b/src/Confide/CacheLoginThrottleService.php
@@ -81,6 +81,8 @@ class CacheLoginThrottleService implements LoginThrottleServiceInterface
                 return serialize($identity);
             }
         }
+
+        return $identity;
     }
 
     /**


### PR DESCRIPTION
When `CacheLoginThrottleService->parseIdentity` received string email from `Confide::logAttempt()` it returned NULL instead of that email
