### PR TITLE
Fixes minor bootstrap 3 issues with login form.

### DIFF
--- a/src/views/login.blade.php
+++ b/src/views/login.blade.php
@@ -1,4 +1,4 @@
-<form method="POST" action="{{{ URL::to('/users/login') }}}" accept-charset="UTF-8">
+<form role="form" method="POST" action="{{{ URL::to('/users/login') }}}" accept-charset="UTF-8">
     <input type="hidden" name="_token" value="{{{ Session::getToken() }}}">
     <fieldset>
         <div class="form-group">
@@ -8,16 +8,16 @@
         <div class="form-group">
         <label for="password">
             {{{ Lang::get('confide::confide.password') }}}
-            <small>
-                <a href="{{{ URL::to('/users/forgot_password') }}}">{{{ Lang::get('confide::confide.login.forgot_password') }}}</a>
-            </small>
         </label>
         <input class="form-control" tabindex="2" placeholder="{{{ Lang::get('confide::confide.password') }}}" type="password" name="password" id="password">
+        <p class="help-block">
+            <a href="{{{ URL::to('/users/forgot_password') }}}">{{{ Lang::get('confide::confide.login.forgot_password') }}}</a>
+        </p>
         </div>
-        <div class="form-group">
-            <label for="remember" class="checkbox">{{{ Lang::get('confide::confide.login.remember') }}}
+        <div class="checkbox">
+            <label for="remember">
                 <input type="hidden" name="remember" value="0">
-                <input tabindex="4" type="checkbox" name="remember" id="remember" value="1">
+                <input tabindex="4" type="checkbox" name="remember" id="remember" value="1"> {{{ Lang::get('confide::confide.login.remember') }}}
             </label>
         </div>
         @if (Session::get('error'))


### PR DESCRIPTION
Fixes the floating checkbox over the "remember me" label per the basic example provided in Bootstrap 3's documentation. 

The default bootstrap CSS applies a negative left margin to the checkbox, so the box should come before the label text. Also, the containing div should be classed as a "checkbox" not "form-control." Also added the 'role="form"' to the form declaration and moved the "forgot password" link to a paragraph classed "help-block" below the password entry for consistency with Bootstrap 3 documentation.
