### PR TITLE
fix to correctly show throttle message

### DIFF
--- a/src/Confide/Confide.php
+++ b/src/Confide/Confide.php
@@ -124,7 +124,7 @@ class Confide
         $remember = $this->extractRememberFromArray($input);
         $emailOrUsername = $this->extractIdentityFromArray($input);
 
-        if (!$this->loginThrottling($emailOrUsername)) {
+        if (!$this->loginThrottling($input)) {
             return false;
         }
 


### PR DESCRIPTION
in order to get and set throttle count on the same cache key, both "loginThrottling" and "isThrottled" should get array as argument.

also, in the config file, there is a comment about remote ip and "login_cache_field" that doesn't seem to have been used for throttling.