### PR TITLE
Update login.blade.php

### DIFF
--- a/src/views/login.blade.php
+++ b/src/views/login.blade.php
@@ -16,7 +16,6 @@
         </div>
         <div class="checkbox">
             <label for="remember">
-                <input type="hidden" name="remember" value="0">
                 <input tabindex="4" type="checkbox" name="remember" id="remember" value="1"> {{{ Lang::get('confide::confide.login.remember') }}}
             </label>
         </div>


### PR DESCRIPTION
The hidden input "remember" overrides whatever the checkbox "remember" has been set to. Hence, setting the "remember me" option on login doesn't work.