### PR TITLE
Wrapped 'orWhere' calls in parameter group to avoid Laravel bug #1945.

### DIFF
--- a/src/Confide/EloquentRepository.php
+++ b/src/Confide/EloquentRepository.php
@@ -66,17 +66,11 @@ class EloquentRepository implements RepositoryInterface
     {
         $user = $this->model();
 
-        $firstWhere = true;
-        foreach ($identity as $attribute => $value) {
-
-            if ($firstWhere) {
-                $user = $user->where($attribute, '=', $value);
-            } else {
+        $user = $user->where(function($user) use ($identity) {
+            foreach ($identity as $attribute => $value) {
                 $user = $user->orWhere($attribute, '=', $value);
             }
-
-            $firstWhere = false;
-        }
+        });
 
         $user = $user->get()->first();
 


### PR DESCRIPTION
As per https://github.com/laravel/framework/issues/1945, using 'orWhere()' in query builder statements does not function as expected when dealing with soft-deleted models. To be precise, the old code would generate SQL statements like this:

> "select \* from `users` where `users`.`deleted_at` is null and `email` = ? or `username` = ?"

Due to operator precedence, this query would only respect soft-deletion for the 'email' field. Any user matching the 'username' field would be retrieved, regardless of soft deletion. In particular, this meant that Confide could authenticate a user that had been previously deleted from the system, since this call occurs during the handling of Confide::logAttempt().

This pull request updates this function to use what appears to be the expected workaround: wrapping the 'orWhere' statements in a nested parameter block. As a result, the SQL generated by this new function looks like:

> "select \* from `users` where `users`.`deleted_at` is null and (`email` = ? or `username` = ?)"

As a result, soft-deleted objects will never be returned by this query.

This is the only use of 'orWhere' statements in Confide, so no additional functions need to be updated.

Additionally, this update removes the 'firstWhere' boolean, which was superfluous within the nested block.
