### PR TITLE
Allows for user update when username is optional

### DIFF
--- a/src/Confide/UserValidator.php
+++ b/src/Confide/UserValidator.php
@@ -117,9 +117,11 @@ class UserValidator implements UserValidatorInterface
     public function validateIsUnique(ConfideUserInterface $user)
     {
         $identity = [
-            'email'    => $user->email,
+            'email' => $user->email,
             'username' => $user->username,
         ];
+
+        $identity = array_filter($identity);
 
         foreach ($identity as $attribute => $value) {
 
@@ -137,7 +139,7 @@ class UserValidator implements UserValidatorInterface
 
         }
 
-        if (!$identity) {
+        if (empty($identity)) {
             return true;
         }
 


### PR DESCRIPTION
When the username is optional, the `validateIsUnique` method wouldn't pass because the `$identity` array was never empty. This ensures it's cleared of all empty values before validating, and then checks empty array.