### PR TITLE
Simplify User entity in sendEmail

### DIFF
--- a/src/Confide/EloquentPasswordService.php
+++ b/src/Confide/EloquentPasswordService.php
@@ -170,6 +170,8 @@ class EloquentPasswordService implements PasswordServiceInterface
     {
         $config = $this->app['config'];
         $lang   = $this->app['translator'];
+        
+        $user = (object)$user->toArray();
 
         $this->app['mailer']->queueOn(
             $config->get('confide::email_queue'),

--- a/src/Confide/EloquentPasswordService.php
+++ b/src/Confide/EloquentPasswordService.php
@@ -172,15 +172,16 @@ class EloquentPasswordService implements PasswordServiceInterface
         $lang   = $this->app['translator'];
         
         $user = (object)$user->toArray();
+        $subject = $lang->get('confide::confide.email.password_reset.subject');
 
         $this->app['mailer']->queueOn(
             $config->get('confide::email_queue'),
             $config->get('confide::email_reset_password'),
             compact('user', 'token'),
-            function ($message) use ($user, $token, $lang) {
+            function ($message) use ($user, $token, $subject) {
                 $message
                     ->to($user->email, $user->username)
-                    ->subject($lang->get('confide::confide.email.password_reset.subject'));
+                    ->subject(subject);
             }
         );
     }


### PR DESCRIPTION
The full User entity throws memory errors, among others, in Laravel 4. This allows the User object to be used.