### PR TITLE
Solves password reset bug

### DIFF
--- a/src/Confide/ConfideUser.php
+++ b/src/Confide/ConfideUser.php
@@ -21,6 +21,13 @@ trait ConfideUser
     public $errors;
 
     /**
+     * A boolean that store if a validation ocurring is for password resetting
+     * only 
+     * @var bool 
+     */
+    private $isResetOnly;
+
+    /**
      * Confirm the user (usually means that the user)
      * email is valid. Sets the confirmed attribute of
      * the user to true and also update the database.
@@ -47,6 +54,15 @@ trait ConfideUser
     }
 
     /**
+     * Set validation method to check only for fields related to password 
+     * resetting
+     * @return void 
+     */
+    public function setResetOnly() {
+        $this->isResetOnly = true;
+    }
+
+    /**
      * Checks if the current user is valid using the ConfideUserValidator.
      *
      * @return bool
@@ -61,6 +77,10 @@ trait ConfideUser
         // If the model already exists in the database we call validate with
         // the update ruleset
         if ($this->exists) {
+            if ($this->isResetOnly) {
+              return $validator->validate($this, 'password_reset');
+            }
+
             return $validator->validate($this, 'update');
         }
 

--- a/src/Confide/ConfideUserInterface.php
+++ b/src/Confide/ConfideUserInterface.php
@@ -24,6 +24,13 @@ interface ConfideUserInterface extends UserInterface, RemindableInterface
     public function confirm();
 
     /**
+     * Set validation method to check only for fields related to password 
+     * resetting
+     * @return void 
+     */
+    public function setResetOnly();
+
+    /**
      * Send email with information about password reset.
      *
      * @return string

--- a/src/Confide/UserValidator.php
+++ b/src/Confide/UserValidator.php
@@ -51,6 +51,9 @@ class UserValidator implements UserValidatorInterface
             'username' => 'alpha_dash',
             'email'    => 'required|email',
             'password' => 'required|min:4',
+        ],
+        'password_reset' => [
+          'password' => 'required|min:4',
         ]
     ];
 
@@ -90,6 +93,9 @@ class UserValidator implements UserValidatorInterface
 
                 // Hashes password and unset password_confirmation field
                 $user->password = $hash->make($user->password);
+                unset($user->password_confirmation);
+
+                return true;
             } else {
                 $this->attachErrorMsg(
                     $user,
@@ -99,8 +105,6 @@ class UserValidator implements UserValidatorInterface
                 return false;
             }
         }
-
-        unset($user->password_confirmation);
 
         return true;
     }

--- a/src/views/generators/controller.blade.php
+++ b/src/views/generators/controller.blade.php
@@ -185,7 +185,8 @@ class {{ $class }} extends Controller
         );
 
         // By passing an array with the token, password and confirmation
-        if ($repo->resetPassword($input)) {
+        $result = $repo->resetPassword( $input );
+        if ( $result['status'] ) {
             $notice_msg = Lang::get('confide::confide.alerts.password_reset');
             return Redirect::action('{{ $namespace ? $namespace.'\\' : '' }}{{ $class }}{{ (! $restful) ? '@login' : '@getLogin' }}')
                 ->with('notice', $notice_msg);
@@ -193,7 +194,8 @@ class {{ $class }} extends Controller
             $error_msg = Lang::get('confide::confide.alerts.wrong_password_reset');
             return Redirect::action('{{ $namespace ? $namespace.'\\' : '' }}{{ $class }}{{ (! $restful) ? '@resetPassword' : '@getReset' }}', array('token'=>$input['token']))
                 ->withInput()
-                ->with('error', $error_msg);
+                ->with('error', $error_msg)
+                ->withErrors($result['errors']);
         }
     }
 

--- a/src/views/generators/repository.blade.php
+++ b/src/views/generators/repository.blade.php
@@ -109,16 +109,19 @@ class UserRepository
     {
         $result = false;
         $user   = Confide::userByResetPasswordToken($input['token']);
+        $user->setResetOnly();
 
         if ($user) {
             $user->password              = $input['password'];
             $user->password_confirmation = $input['password_confirmation'];
-            $result = $this->save($user);
+            $result['status'] = $this->save($user);
         }
 
-        // If result is positive, destroy token
-        if ($result) {
+        // If result status is positive, destroy token
+        if ($result['status']) {
             Confide::destroyForgotPasswordToken($input['token']);
+        } else {
+            $result['errors'] = $user->errors;
         }
 
         return $result;


### PR DESCRIPTION
Relates to #482

Password reset is validated by the same ruleset that any
regular update is. It's going to fail everytime because instead of
sending the required fields for `update` ruleset validation, it's only sending
`password` and `password_confirmation`.

This PR adds a method on `ConfideUser` that provides a `boolean` to be
checked at `save` method and change the ruleset to `'password_reset`' which
requires only `password` and `password_confirmation` to pass on.

Due to the `boolean` variable that needs to get passed on `passwordReset`
`UserRepository` and `UserController` suffered minor changes.

This PR also allows all accordingly validation messages to be sent to final user
instead of only showing him/her a generic Confide Lang defined error
message.

Dunno if this will break any tests, take it as a proposal template if so.

:beers:
