### PR TITLE
Eliminate dependency on email address as a reliable handle for user

### DIFF
--- a/src/Confide/Confide.php
+++ b/src/Confide/Confide.php
@@ -233,11 +233,12 @@ class Confide
      *
      * @return string $token
      */
-    public function forgotPassword($email)
+    public function forgotPassword($emailorusername)
     {
-        $user = $this->repo->getUserByEmail($email);
+        $user = $this->repo->getUserByEmailOrUsername($emailorusername);
 
-        if ($user) {
+        if ($user) 
+        {
             return $this->passService->requestChangePassword($user);
         }
 
@@ -266,6 +267,13 @@ class Confide
      */
     public function userByResetPasswordToken($token)
     {
+        $id = $this->passService->getUserIdentityByToken($token);
+
+        if($id)
+        {
+            return $this->repo->getUserByIdentity($id);
+        }
+
         $email = $this->passService->getEmailByToken($token);
 
         if ($email) {

--- a/src/Confide/EloquentPasswordService.php
+++ b/src/Confide/EloquentPasswordService.php
@@ -38,10 +38,10 @@ class EloquentPasswordService implements PasswordServiceInterface
      */
     public function requestChangePassword(RemindableInterface $user)
     {
-        $email = $user->getReminderEmail();
         $token = $this->generateToken();
 
         $values = array(
+            'user_id' => $user->id,
             'email'=> $email,
             'token'=> $token,
             'created_at'=> new \DateTime
@@ -67,22 +67,24 @@ class EloquentPasswordService implements PasswordServiceInterface
      *
      * @return string Email.
      */
-    public function getEmailByToken($token)
+    public function getUserIdentityByToken($token)
     {
         $connection = $this->getConnection();
         $table = $this->getTable();
 
-        $email = $this->app['db']
+        $id = $this->app['db']
             ->connection($connection)
             ->table($table)
-            ->select('email')
+            ->select('user_id')
             ->where('token', '=', $token)
             ->where('created_at', '>=', $this->getOldestValidDate())
             ->first();
 
-        $email = $this->unwrapEmail($email);
-
-        return $email;
+        if($id)
+        {
+            $id = ['id' => $id->user_id];
+        }
+        return $id;
     }
 
     /**
@@ -139,23 +141,6 @@ class EloquentPasswordService implements PasswordServiceInterface
         return md5(uniqid(mt_rand(), true));
     }
 
-    /**
-     * Extracts the email of the given object or array.
-     *
-     * @param mixed $email An object, array or email string.
-     *
-     * @return string The email address.
-     */
-    protected function unwrapEmail($email)
-    {
-        if ($email && is_object($email)) {
-            $email = $email->email;
-        } elseif ($email && is_array($email)) {
-            $email = $email['email'];
-        }
-
-        return $email;
-    }
 
     /**
      * Sends an email containing the reset password link with the
@@ -168,6 +153,8 @@ class EloquentPasswordService implements PasswordServiceInterface
      */
     protected function sendEmail($user, $token)
     {
+        $email = $user->getReminderEmail();
+
         $config = $this->app['config'];
         $lang   = $this->app['translator'];
 
@@ -177,7 +164,7 @@ class EloquentPasswordService implements PasswordServiceInterface
             compact('user', 'token'),
             function ($message) use ($user, $token, $lang) {
                 $message
-                    ->to($user->email, $user->username)
+                    ->to($email, $user->username)
                     ->subject($lang->get('confide::confide.email.password_reset.subject'));
             }
         );

--- a/src/Confide/EloquentPasswordService.php
+++ b/src/Confide/EloquentPasswordService.php
@@ -1,7 +1,7 @@
 <?php namespace Zizaco\Confide;
 
 use Illuminate\Auth\Reminders\RemindableInterface;
-
+use DateTime;
 /**
  * A service that abstracts all user password management related methods.
  *
@@ -41,10 +41,10 @@ class EloquentPasswordService implements PasswordServiceInterface
         $token = $this->generateToken();
 
         $values = array(
-            'user_id' => $user->id,
-            'email'=> $email,
+            'user_id' => $user->getAuthIdentifier(),
+            'email'=> $user->getReminderEmail(),
             'token'=> $token,
-            'created_at'=> new \DateTime
+            'created_at'=> new DateTime
         );
 
         $table = $this->getTable();

--- a/src/Confide/EloquentRepository.php
+++ b/src/Confide/EloquentRepository.php
@@ -98,12 +98,17 @@ class EloquentRepository implements RepositoryInterface
      */
     public function getUserByEmailOrUsername($emailOrUsername)
     {
-        $identity = [
-            'email' => $emailOrUsername,
-            'username' => $emailOrUsername
-        ];
+        $user = $this->getUserByUsername($emailOrUsername);
+        if(!$user)
+        {
+            $user = $this->getUserByEmail($emailOrUsername);
+        }
+        return $user;
+    }
 
-        return $this->getUserByIdentity($identity);
+    public function getUserByUsername($username)
+    {
+        return $this->getUserByIdentity(['username' => $username]);
     }
 
     /**

--- a/src/Confide/PasswordServiceInterface.php
+++ b/src/Confide/PasswordServiceInterface.php
@@ -21,13 +21,13 @@ interface PasswordServiceInterface
     public function requestChangePassword(RemindableInterface $user);
 
     /**
-     * Returns the email associated with the given reset password token.
+     * Returns the user id associated with the given reset password token.
      *
      * @param string $token
      *
-     * @return string Email.
+     * @return mixed id.
      */
-    public function getEmailByToken($token);
+    public function getUserIdentityByToken($token);
 
     /**
      * Delete the record of the given token from database.

--- a/src/commands/ControllerCommand.php
+++ b/src/commands/ControllerCommand.php
@@ -52,6 +52,11 @@ class ControllerCommand extends GenerateCommand
         $model = $this->app['config']->get('auth.model');
         $restful = $this->option('restful');
         $includeUsername = $this->option('username');
+        $includeEmail = $this->option('email');
+        if(!$includeUsername && !$includeEmail)
+        {
+            $includeUsername = true;
+        }
 
         $viewVars = compact(
             'class',

--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -47,6 +47,11 @@ class MigrationCommand extends GenerateCommand
         // Prepare variables
         $table = lcfirst($this->option('table'));
         $includeUsername = $this->option('username');
+        $includeEmail = $this->option('email');
+        if(!$includeUsername && !$includeEmail)
+        {
+            $includeUsername = true;
+        }
 
         $viewVars = compact(
             'table',
@@ -63,6 +68,11 @@ class MigrationCommand extends GenerateCommand
         if ($includeUsername) {
             $this->comment(
                 "An 'username' column will be included in the table."
+            );
+        }
+        if ($includeEmail) {
+            $this->comment(
+                "An 'email' column will be included in the table."
             );
         }
         $this->line('');

--- a/src/views/generators/migration.blade.php
+++ b/src/views/generators/migration.blade.php
@@ -15,7 +15,9 @@ class ConfideSetupUsersTable extends Migration
 @if ($includeUsername)
             $table->string('username')->unique();
 @endif
+@if ($includeEmail)
             $table->string('email')->unique();
+@endif
             $table->string('password');
             $table->string('confirmation_code');
             $table->string('remember_token')->nullable();
@@ -25,9 +27,11 @@ class ConfideSetupUsersTable extends Migration
 
         // Creates password reminders table
         Schema::create('password_reminders', function ($table) {
+            $table->integer('user_id');
             $table->string('email');
             $table->string('token');
             $table->timestamp('created_at');
+            $table->primary('token');
         });
     }
 

--- a/src/views/generators/repository.blade.php
+++ b/src/views/generators/repository.blade.php
@@ -19,7 +19,7 @@ class UserRepository
     /**
      * Signup a new account with the given parameters
      *
-     * @param array $input Array containing {{ ($includeUsername) ? "'username', " : '' }}'email' and 'password'.
+     * @param array $input Array containing {{ ($includeUsername) ? "'username', " : '' }} {{ ($includeEmail) ? "'email', " : '' }} and 'password'.
      *
      * @return {{ $nonNamespacedName }} {{ $nonNamespacedName }} object that may or may not be saved successfully. Check the id to make sure.
      */
@@ -30,7 +30,9 @@ class UserRepository
 @if ($includeUsername)
         $user->username = array_get($input, 'username');
 @endif
+@if ($includeEmail)
         $user->email    = array_get($input, 'email');
+@endif
         $user->password = array_get($input, 'password');
 
         // The password confirmation will be removed from model


### PR DESCRIPTION
Not all my users have email, some have more than one email.  Since an email is just a bit of contact info, I don't have it as a field in user.  I have it as a related table so users can have multiple.  This keeps confide from being useful to me and anyone else who didn't tie email address to user identity.

The most egregious evidence of this is 
```
    public function userByResetPasswordToken($token)
    {
        $email = $this->passService->getEmailByToken($token);
        if ($email) {
            return $this->repo->getUserByEmail($email);
        }
        return false;
    }
```

because I can't look up a user by email.  This change set adds the primary key for the user to the password reset table.

```
    public function requestChangePassword(RemindableInterface $user)
    {
        $token = $this->generateToken();

        $values = array(
            'user_id' => $user->getAuthIdentifier(),
            'email'=> $user->getReminderEmail(),
            'token'=> $token,
            'created_at'=> new DateTime
        );

        $table = $this->getTable();

        $this->app['db']
            ->connection($user->getConnectionName())
            ->table($table)
            ->insert($values);

        $this->sendEmail($user, $token);

        return $token;
    }

```
and so now the user is looked up by primary key instead of by email.  There are a few more changes around making email optional in the database when generating controllers and database tables and there is more support for using username (although this isn't necessarily unique in my system either).
