### PR TITLE
Fixed bugs with config names

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Confide::makeResetPasswordForm($token):
 You would use:
 
 ```php
-View::make(Config::get('confide::reset_password_form'))
+View::make(Config::get('confide.reset_password_form'))
     ->with('token', $token);
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,6 @@
             "src/migrations",
             "src/commands"
         ],
-        "files": [
-            "tests/Confide/helpers.php"
-        ],
         "psr-4": {
             "Zizaco\\Confide\\": "src/Confide/"
         }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
             "src/migrations",
             "src/commands"
         ],
+        "files": [
+            "tests/Confide/helpers.php"
+        ],
         "psr-4": {
             "Zizaco\\Confide\\": "src/Confide/"
         }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
             "src/migrations",
             "src/commands"
         ],
+        "files": [
+            "src/Confide/helpers.php"
+        ],
         "psr-4": {
             "Zizaco\\Confide\\": "src/Confide/"
         }

--- a/src/Confide/CacheLoginThrottleService.php
+++ b/src/Confide/CacheLoginThrottleService.php
@@ -59,7 +59,7 @@ class CacheLoginThrottleService implements LoginThrottleServiceInterface
         // Retuns the current count
         $count = $this->countThrottle($identity, 0);
 
-        return $count >= $this->app->make('config')->get('confide::throttle_limit');
+        return $count >= $this->app->make('config')->get('confide.throttle_limit');
     }
 
     /**
@@ -104,7 +104,7 @@ class CacheLoginThrottleService implements LoginThrottleServiceInterface
 
         $count = $count + $increments;
 
-        $ttl = $this->app->make('config')->get('confide::throttle_time_period');
+        $ttl = $this->app->make('config')->get('confide.throttle_time_period');
 
         $this->app->make('cache')
             ->put('login_throttling:'.md5($identityString), $count, $ttl);

--- a/src/Confide/Confide.php
+++ b/src/Confide/Confide.php
@@ -201,7 +201,7 @@ class Confide
         $count = $this->loginThrottler
             ->throttleIdentity($identity);
 
-        if ($count >= $this->app->make('config')->get('confide::throttle_limit')) {
+        if ($count >= $this->app->make('config')->get('confide.throttle_limit')) {
             return false;
         }
 
@@ -292,7 +292,7 @@ class Confide
      */
     public function makeLoginForm()
     {
-        return $this->app->make('view')->make($this->app->make('config')->get('confide::login_form'));
+        return $this->app->make('view')->make($this->app->make('config')->get('confide.login_form'));
     }
 
     /**
@@ -302,7 +302,7 @@ class Confide
      */
     public function makeSignupForm()
     {
-        return $this->app->make('view')->make($this->app->make('config')->get('confide::signup_form'));
+        return $this->app->make('view')->make($this->app->make('config')->get('confide.signup_form'));
     }
 
     /**
@@ -312,7 +312,7 @@ class Confide
      */
     public function makeForgotPasswordForm()
     {
-        return $this->app->make('view')->make($this->app->make('config')->get('confide::forgot_password_form'));
+        return $this->app->make('view')->make($this->app->make('config')->get('confide.forgot_password_form'));
     }
 
     /**
@@ -323,7 +323,7 @@ class Confide
     public function makeResetPasswordForm($token)
     {
         return $this->app->make('view')->make(
-            $this->app->make('config')->get('confide::reset_password_form'),
+            $this->app->make('config')->get('confide.reset_password_form'),
             array('token' => $token)
         );
     }

--- a/src/Confide/EloquentPasswordService.php
+++ b/src/Confide/EloquentPasswordService.php
@@ -173,8 +173,8 @@ class EloquentPasswordService implements PasswordServiceInterface
         $lang   = $this->app->make('translator');
 
         $this->app->make('mailer')->queueOn(
-            $config->get('confide::email_queue'),
-            $config->get('confide::email_reset_password'),
+            $config->get('confide.email_queue'),
+            $config->get('confide.email_reset_password'),
             compact('user', 'token'),
             function ($message) use ($user, $token, $lang) {
                 $message
@@ -197,7 +197,7 @@ class EloquentPasswordService implements PasswordServiceInterface
         $config = $this->app->make('config');
 
         return $carbon->now()
-            ->subHours($config->get('confide::confide.password_reset_expiration', 7))
+            ->subHours($config->get('confide.confide.password_reset_expiration', 7))
             ->toDateTimeString();
     }
 }

--- a/src/Confide/helpers.php
+++ b/src/Confide/helpers.php
@@ -2,5 +2,5 @@
 
 function config_path($path)
 {
-    return 'test/' . $path;
+    return 'config/' . $path;
 }


### PR DESCRIPTION
Switched from config 'confide::name' to 'confide.name' for Laravel5.
