### PR TITLE
Adding security

### DIFF
--- a/src/Confide/CacheLoginThrottleService.php
+++ b/src/Confide/CacheLoginThrottleService.php
@@ -98,14 +98,14 @@ class CacheLoginThrottleService implements LoginThrottleServiceInterface
     protected function countThrottle($identityString, $increments = 1)
     {
         $count = $this->app['cache']
-            ->get('login_throttling:'.md5($identityString), 0);
+            ->get('login_throttling:'.md5($identityString.$this->app['request']->server('REMOTE_ADDR')), 0);
 
         $count = $count + $increments;
 
         $ttl = $this->app['config']->get('confide::throttle_time_period');
 
         $this->app['cache']
-            ->put('login_throttling:'.md5($identityString), $count, $ttl);
+            ->put('login_throttling:'.md5($identityString.$this->app['request']->server('REMOTE_ADDR')), $count, $ttl);
 
         return $count;
     }

--- a/src/Confide/Confide.php
+++ b/src/Confide/Confide.php
@@ -264,16 +264,16 @@ class Confide
      *
      * @return ConfideUser
      */
-    public function userByResetPasswordToken($token)
-    {
+     public function userByResetPasswordToken($token)
+     {
         $email = $this->passService->getEmailByToken($token);
 
         if ($email) {
-            return $this->repo->getUserByEmail($email);
+          return $this->repo->getUserByEmail($email);
         }
 
         return false;
-    }
+     }
 
     /**
      * Log the user out of the application.

--- a/src/Confide/Confide.php
+++ b/src/Confide/Confide.php
@@ -235,13 +235,16 @@ class Confide
      */
     public function forgotPassword($email)
     {
-        $user = $this->repo->getUserByEmail($email);
+      if($this->passService->isThrottled()) return 'trottling';
 
-        if ($user) {
-            return $this->passService->requestChangePassword($user);
-        }
+      $user = $this->repo->getUserByEmail($email);
 
-        return false;
+      if ($user) {
+          return $this->passService->requestChangePassword($user);
+      }
+      $this->passService->countThrottle();
+
+      return false;
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -85,6 +85,18 @@ return array(
 
     /*
     |--------------------------------------------------------------------------
+    | Password reset Throttle
+    |--------------------------------------------------------------------------
+    |
+    | Defines how many wrong email failed tries from one IP may be done within
+    | the 'reset_password_throttle_time_period', which is in minutes.
+    |
+    */
+    'reset_password_throttle_limit' => 4,
+    'reset_password_throttle_time_period' => 15,
+
+    /*
+    |--------------------------------------------------------------------------
     | Signup E-mail and confirmation (true or false)
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Bind the login attempts to the IP address. As the blocking is NOT bound to an IP address, it is possible to block legitimate users, automatically trying to log with incorrect credentials every few minutes.

Limit the usage of "reset password" to prevent spamming the user with known email, it would be efficient in most cases to use it only a few times per day.

Add throttling to "reset password" functionality for wrong identity to prevent determination of the existence of valid email addresses.
